### PR TITLE
Passing keyword arguments to the client processes

### DIFF
--- a/client-process.lisp
+++ b/client-process.lisp
@@ -30,6 +30,9 @@
 (defparameter *process-fn* nil
   "The name of the client process.")
 
+(defparameter *process-fn-kwargs* nil
+  "The keyword arguments of the client process.")
+
 (defparameter *write-fn* nil
   "The name of the client process.")
 
@@ -48,6 +51,7 @@
 (defun initialise-process (&key lock-file
                                 output-file
                                 process-fn
+                                process-fn-kwargs
                                 write-fn
                                 keep-order)
   "Initialises the cl-pcp client process by setting the relevant global variables."
@@ -55,15 +59,19 @@
   (setf *lock-file* lock-file
         *output-file* output-file
         *process-fn* process-fn
+        *process-fn-kwargs* process-fn-kwargs
         *write-fn* write-fn
         *keep-order* keep-order)
   (delete-file *lock-file*)
-  (format nil "Process initialised with lock-file: ~s, temporary output-file: ~s, process-fn: ~a, write-fn: ~a and keep-order: ~a."
-          lock-file output-file process-fn write-fn keep-order))
+  (format nil "Process initialised with lock-file: ~s, temporary output-file: ~s, process-fn: ~a, process-fn-kwargs: ~a, write-fn: ~a and keep-order: ~a."
+          lock-file output-file process-fn process-fn-kwargs write-fn keep-order))
 
 (defun run (item-nr input)
   "Runs the client process for input."
-  (let* ((processed-input (funcall *process-fn* input)))
+  (let* ((processed-input
+          (if (null *process-fn-kwargs*)
+            (funcall *process-fn* input)
+            (apply *process-fn* input *process-fn-kwargs*))))
     ;; Now write the output
     (with-open-file (stream *output-file* :direction :output :if-does-not-exist :create :if-exists :append)
       (if *keep-order*

--- a/demo.lisp
+++ b/demo.lisp
@@ -82,7 +82,19 @@
                              :process-fn 'cl-pcp::use-cpu ;; function to process each item of the corpus
                              :write-fn 'identity ;; transform the data resulting from process-fn to write away
                              :nr-of-processes 8  ;; number of subprocesses to use (do not exceed nr of cores on your machine)
-                             :keep-order t)) ;; Keep order of items in corpus 
+                             :keep-order t)) ;; Keep order of items in corpus
+
+(time
+ (process-corpus-in-parallel *benchmark-data-input-file* ;; input file with corpus
+                             *benchmark-data-output-file* ;; output file for processed corpus
+                             :external-lisp *external-lisp* ;; underlying lisp implementation to use (:lispworks :ccl :sbcl)
+                             :asdf-systems nil ;; asdf-systems to are used (to be loaded by the client processes)
+                             :read-fn 'read-from-stream ;; function to use for rading from stream connected to input file ('read-from-stream 'read-line-from-stream)
+                             :process-fn 'cl-pcp::use-cpu-with-kwargs ;; function to process each item of the corpus
+                             :process-fn-kwargs '(:symbol-key foo :string-key "bar" :number-key 5 :list-key (a "a" 5))
+                             :write-fn 'identity ;; transform the data resulting from process-fn to write away
+                             :nr-of-processes 4  ;; number of subprocesses to use (do not exceed nr of cores on your machine)
+                             :keep-order nil)) ;; Keep order of items in corpus 
 
 
 

--- a/utilities.lisp
+++ b/utilities.lisp
@@ -44,3 +44,13 @@
   (loop for i from 1 upto (* load 1000000000)
         do (* i load)
         finally (return load)))
+
+;; For demo purposes.
+(defun use-cpu-with-kwargs (load &key symbol-key string-key number-key list-key)
+  (print symbol-key)
+  (print string-key)
+  (print number-key)
+  (print list-key)
+  (loop for i from 1 upto (* load 1000000000)
+        do (* i load)
+        finally (return load)))


### PR DESCRIPTION
With these changes, it is now possible to pass keyword arguments to the client processes. The list of keyword arguments should be formatted as `(:key value)`, where `:key` is any of the keyword arguments of the user-defined processing function and `value` is a keyword, a symbol, a string, a number, or a list of any of these values.