### PR TITLE
Updates after using cl-pcp in HPC

### DIFF
--- a/cl-pcp.asd
+++ b/cl-pcp.asd
@@ -16,10 +16,9 @@
 (in-package :asdf)
 
 (defsystem cl-pcp
-  :author ""
-  :maintainer ""
-  :license ""
-  :homepage ""
+  :author "Remi van Trijp (remi.vantrijp@sony.com)"
+  :license "Apache 2.0"
+  :homepage "https://github.com/SonyCSLParis/cl-pcp"
   :serial t
   :depends-on (bordeaux-threads split-sequence)
   :components ((:file "package")

--- a/client-process.lisp
+++ b/client-process.lisp
@@ -63,8 +63,7 @@
         *write-fn* write-fn
         *keep-order* keep-order)
   ;; Delete the lock file
-  (loop with successful = nil until successful
-        do (setf successful (delete-file lock-file)))
+  (safe-delete-file lock-file)
   (format nil "Process initialised with lock-file: ~s, temporary output-file: ~s, process-fn: ~a, process-fn-kwargs: ~a, write-fn: ~a and keep-order: ~a."
           lock-file output-file process-fn process-fn-kwargs write-fn keep-order))
 
@@ -83,6 +82,5 @@
       (finish-output stream)))
   ;; Finally, unlock the process by deleting the lock file.
   (let ((lock-file-path (parse-namestring lock-file)))
-    (loop with successful = nil until successful
-          do (setf successful (delete-file lock-file-path))))
+    (safe-delete-file lock-file-path))
   (format nil "Item ~a done." item-nr))

--- a/package.lisp
+++ b/package.lisp
@@ -15,5 +15,12 @@
 
 (defpackage :cl-pcp
   (:use :cl)
-  (:export)
+  (:import-from :split-sequence
+                :split-sequence)
+  (:import-from :bordeaux-threads
+                :make-thread
+                :join-thread)
+  (:export :process-corpus-in-parallel
+           :read-from-stream
+           :read-line-from-stream)
   (:documentation "A package for parallel corpus processing."))

--- a/server-process.lisp
+++ b/server-process.lisp
@@ -112,7 +112,7 @@
                           :type "lock")
            (temp-directory client-process))))
   (when (probe-file (lock-file client-process))
-    (delete-file (lock-file client-process)))
+    (safe-delete-file (lock-file client-process)))
   ;; Output-file
   (unless (output-file client-process)
     (setf (output-file client-process)
@@ -121,13 +121,12 @@
                           :type "out")
            (temp-directory client-process))))
   (when (probe-file (output-file client-process))
-    (delete-file (output-file client-process))))
+    (safe-delete-file (output-file client-process))))
 
 (defmethod terminate ((client-process client-process))
   "Terminates a client-process cleanly."
   (when (probe-file (lock-file client-process))
-    (loop with successful = nil until successful
-          do (setf successful (delete-file (lock-file client-process)))))
+    (safe-delete-file (lock-file client-process)))
   (uiop/launch-program:terminate-process (process client-process))
   (join-thread (reader-thread client-process)))
 
@@ -158,8 +157,7 @@
 (defun unlock (client-process)
   "Unlock client process."
   (when (probe-file (lock-file client-process))
-    (loop with successful = nil until successful
-        do (setf successful (delete-file (lock-file client-process))))))
+    (safe-delete-file (lock-file client-process))))
 
 (defun format-kwargs-list (kwargs)
   "Helper function for formatting the keyword
@@ -313,7 +311,7 @@
           
           (loop for file in (mapcar #'output-file processes)
                 when (probe-file file)
-                  do (delete-file file))
+                do (delete-file file))
           (format t "~%Output written to: ~a~%" output-file)
           
           ;; Finally kill the processes

--- a/server-process.lisp
+++ b/server-process.lisp
@@ -332,7 +332,7 @@
                  (loop for process in client-processes
                        if (idle process)
                        return process
-                       else do (sleep 0.1)))
+                       else do (sleep 0.2)))
         finally (return idle-process)))
 
 (defun wait-until-all-process-idle (client-processes)

--- a/utilities.lisp
+++ b/utilities.lisp
@@ -39,6 +39,20 @@
   (force-output outputstream)
   (finish-output outputstream))
 
+(defun safe-delete-file (file &key (max-attempts 10))
+  (let ((file-deleted-p
+         (loop with successful = nil
+               for attempts from 1
+               until (or successful (> attempts max-attempts))
+               do
+                 (setf successful
+                       (handler-case (delete-file file)
+                         (file-error (error) nil)))
+                 (sleep 0.1)
+               finally (return successful))))
+    (unless file-deleted-p
+      (error "Could not delete the file ~a" file))))
+         
 ;; For demo purposes.
 (defun use-cpu (load)
   "Uses CPU for about load seconds (on i7)."

--- a/utilities.lisp
+++ b/utilities.lisp
@@ -36,7 +36,8 @@
 (defun write-line-to-stream (outputstream result)
   "Writes a line to a stream and flushes."
   (format outputstream "~a~%" result)
-  (force-output outputstream))
+  (force-output outputstream)
+  (finish-output outputstream))
 
 ;; For demo purposes.
 (defun use-cpu (load)


### PR DESCRIPTION
I was running into issues where the server process was probing the existence of a lock file, while the client process was removing this exact lock file. To counteract this issue, I have made the following changes:
- the client processes get a unique lock file for every line they process, instead of reusing the same file each time.
- the server process polls the client processes less frequent (every 0.1 second instead of every 0.01 second)

Other changes are:
- the server process cycles through the client processes such that work is more evenly distributed
- more information gets printed at the start of corpus processing
- I have updated the .asd and package.lisp files such that cl-pcp may be distributed via quicklisp